### PR TITLE
chore: publish to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: https://npm.pkg.github.com
+          registry-url: https://registry.npmjs.org/
           scope: "@use-tusk"
 
       - name: Install dependencies
@@ -36,5 +36,5 @@ jobs:
 
       - name: Publish to GitHub Packages
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish

--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "files": [
     "dist/**"
   ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "exports": {
     "./backend/onboarding_service": {
       "import": "./dist/backend/onboarding_service.js",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Publish to npmjs.org instead of GitHub Packages, updating auth token and adding publishConfig.
> 
> - **CI/CD**:
>   - Update `.github/workflows/publish.yml` to publish to `https://registry.npmjs.org/` instead of GitHub Packages.
>   - Use `NODE_AUTH_TOKEN` from `${{ secrets.NPM_TOKEN }}` instead of `${{ secrets.GITHUB_TOKEN }}`.
> - **Package config**:
>   - Add `publishConfig` with `access: public` and `registry: https://registry.npmjs.org/` in `package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52c6d1997736bcf594c751b9335989c7f961e56c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->