### PR TITLE
feat: expand local code review request with branch + SHA context

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -10,3 +10,9 @@ lint:
 breaking:
   use:
     - FILE
+  # Remove in next commit, added because wanted to change field name that wasn't in use yet
+  ignore_only:
+    FIELD_SAME_NAME:
+      - proto/backend/code_review_service.proto
+    FIELD_SAME_JSON_NAME:
+      - proto/backend/code_review_service.proto

--- a/generated/go/backend/code_review_service.pb.go
+++ b/generated/go/backend/code_review_service.pb.go
@@ -88,6 +88,7 @@ const (
 	CreateLocalCodeReviewRunResponseErrorCode_CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_REPO_NOT_FOUND CreateLocalCodeReviewRunResponseErrorCode = 3
 	CreateLocalCodeReviewRunResponseErrorCode_CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_PATCH_INVALID  CreateLocalCodeReviewRunResponseErrorCode = 4
 	CreateLocalCodeReviewRunResponseErrorCode_CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_RATE_LIMITED   CreateLocalCodeReviewRunResponseErrorCode = 5
+	CreateLocalCodeReviewRunResponseErrorCode_CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_NO_SEAT        CreateLocalCodeReviewRunResponseErrorCode = 6
 )
 
 // Enum value maps for CreateLocalCodeReviewRunResponseErrorCode.
@@ -99,6 +100,7 @@ var (
 		3: "CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_REPO_NOT_FOUND",
 		4: "CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_PATCH_INVALID",
 		5: "CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_RATE_LIMITED",
+		6: "CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_NO_SEAT",
 	}
 	CreateLocalCodeReviewRunResponseErrorCode_value = map[string]int32{
 		"CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_UNSPECIFIED":    0,
@@ -107,6 +109,7 @@ var (
 		"CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_REPO_NOT_FOUND": 3,
 		"CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_PATCH_INVALID":  4,
 		"CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_RATE_LIMITED":   5,
+		"CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_NO_SEAT":        6,
 	}
 )
 
@@ -245,11 +248,18 @@ type CreateLocalCodeReviewRunRequest struct {
 	state     protoimpl.MessageState `protogen:"open.v1"`
 	OwnerName string                 `protobuf:"bytes,1,opt,name=owner_name,json=ownerName,proto3" json:"owner_name,omitempty"`
 	RepoName  string                 `protobuf:"bytes,2,opt,name=repo_name,json=repoName,proto3" json:"repo_name,omitempty"`
-	// Commit the patch applies on top of
-	BaseSha       string  `protobuf:"bytes,3,opt,name=base_sha,json=baseSha,proto3" json:"base_sha,omitempty"`
-	Patch         []byte  `protobuf:"bytes,4,opt,name=patch,proto3" json:"patch,omitempty"`
-	MinSeverity   *string `protobuf:"bytes,5,opt,name=min_severity,json=minSeverity,proto3,oneof" json:"min_severity,omitempty"`
-	CliVersion    string  `protobuf:"bytes,6,opt,name=cli_version,json=cliVersion,proto3" json:"cli_version,omitempty"`
+	// Most recent commit on this branch reachable on origin
+	LastPushedSha string `protobuf:"bytes,3,opt,name=last_pushed_sha,json=lastPushedSha,proto3" json:"last_pushed_sha,omitempty"`
+	// Diff between `last_pushed_sha` and the working tree (unpushed commits
+	// + uncommitted changes only)
+	Patch       []byte  `protobuf:"bytes,4,opt,name=patch,proto3" json:"patch,omitempty"`
+	MinSeverity *string `protobuf:"bytes,5,opt,name=min_severity,json=minSeverity,proto3,oneof" json:"min_severity,omitempty"`
+	CliVersion  string  `protobuf:"bytes,6,opt,name=cli_version,json=cliVersion,proto3" json:"cli_version,omitempty"`
+	// Current branch name. Backend uses it to look up the open PR for seat
+	// resolution, `base_branch` defaulting, and PR context.
+	BranchName string `protobuf:"bytes,7,opt,name=branch_name,json=branchName,proto3" json:"branch_name,omitempty"`
+	// The user's actual local HEAD commit
+	LocalHeadSha  string `protobuf:"bytes,8,opt,name=local_head_sha,json=localHeadSha,proto3" json:"local_head_sha,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -298,9 +308,9 @@ func (x *CreateLocalCodeReviewRunRequest) GetRepoName() string {
 	return ""
 }
 
-func (x *CreateLocalCodeReviewRunRequest) GetBaseSha() string {
+func (x *CreateLocalCodeReviewRunRequest) GetLastPushedSha() string {
 	if x != nil {
-		return x.BaseSha
+		return x.LastPushedSha
 	}
 	return ""
 }
@@ -322,6 +332,20 @@ func (x *CreateLocalCodeReviewRunRequest) GetMinSeverity() string {
 func (x *CreateLocalCodeReviewRunRequest) GetCliVersion() string {
 	if x != nil {
 		return x.CliVersion
+	}
+	return ""
+}
+
+func (x *CreateLocalCodeReviewRunRequest) GetBranchName() string {
+	if x != nil {
+		return x.BranchName
+	}
+	return ""
+}
+
+func (x *CreateLocalCodeReviewRunRequest) GetLocalHeadSha() string {
+	if x != nil {
+		return x.LocalHeadSha
 	}
 	return ""
 }
@@ -988,16 +1012,19 @@ var File_backend_code_review_service_proto protoreflect.FileDescriptor
 
 const file_backend_code_review_service_proto_rawDesc = "" +
 	"\n" +
-	"!backend/code_review_service.proto\x12\x15tusk.drift.backend.v1\"\xe8\x01\n" +
+	"!backend/code_review_service.proto\x12\x15tusk.drift.backend.v1\"\xbc\x02\n" +
 	"\x1fCreateLocalCodeReviewRunRequest\x12\x1d\n" +
 	"\n" +
 	"owner_name\x18\x01 \x01(\tR\townerName\x12\x1b\n" +
-	"\trepo_name\x18\x02 \x01(\tR\brepoName\x12\x19\n" +
-	"\bbase_sha\x18\x03 \x01(\tR\abaseSha\x12\x14\n" +
+	"\trepo_name\x18\x02 \x01(\tR\brepoName\x12&\n" +
+	"\x0flast_pushed_sha\x18\x03 \x01(\tR\rlastPushedSha\x12\x14\n" +
 	"\x05patch\x18\x04 \x01(\fR\x05patch\x12&\n" +
 	"\fmin_severity\x18\x05 \x01(\tH\x00R\vminSeverity\x88\x01\x01\x12\x1f\n" +
 	"\vcli_version\x18\x06 \x01(\tR\n" +
-	"cliVersionB\x0f\n" +
+	"cliVersion\x12\x1f\n" +
+	"\vbranch_name\x18\a \x01(\tR\n" +
+	"branchName\x12$\n" +
+	"\x0elocal_head_sha\x18\b \x01(\tR\flocalHeadShaB\x0f\n" +
 	"\r_min_severity\"@\n" +
 	"'CreateLocalCodeReviewRunResponseSuccess\x12\x15\n" +
 	"\x06run_id\x18\x01 \x01(\tR\x05runId\"\xe4\x01\n" +
@@ -1045,14 +1072,15 @@ const file_backend_code_review_service_proto_rawDesc = "" +
 	"\x1eCODE_REVIEW_RUN_STATUS_RUNNING\x10\x02\x12\"\n" +
 	"\x1eCODE_REVIEW_RUN_STATUS_SUCCESS\x10\x03\x12!\n" +
 	"\x1dCODE_REVIEW_RUN_STATUS_FAILED\x10\x04\x12$\n" +
-	" CODE_REVIEW_RUN_STATUS_CANCELLED\x10\x05*\xbd\x03\n" +
+	" CODE_REVIEW_RUN_STATUS_CANCELLED\x10\x05*\xfb\x03\n" +
 	")CreateLocalCodeReviewRunResponseErrorCode\x12@\n" +
 	"<CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_UNSPECIFIED\x10\x00\x12=\n" +
 	"9CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_INTERNAL\x10\x01\x12C\n" +
 	"?CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_NOT_AUTHORIZED\x10\x02\x12C\n" +
 	"?CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_REPO_NOT_FOUND\x10\x03\x12B\n" +
 	">CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_PATCH_INVALID\x10\x04\x12A\n" +
-	"=CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_RATE_LIMITED\x10\x05*\xab\x02\n" +
+	"=CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_RATE_LIMITED\x10\x05\x12<\n" +
+	"8CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_NO_SEAT\x10\x06*\xab\x02\n" +
 	"'GetCodeReviewRunStatusResponseErrorCode\x12>\n" +
 	":GET_CODE_REVIEW_RUN_STATUS_RESPONSE_ERROR_CODE_UNSPECIFIED\x10\x00\x12;\n" +
 	"7GET_CODE_REVIEW_RUN_STATUS_RESPONSE_ERROR_CODE_INTERNAL\x10\x01\x12A\n" +

--- a/generated/python/tusk/drift/backend/v1/__init__.py
+++ b/generated/python/tusk/drift/backend/v1/__init__.py
@@ -80,6 +80,7 @@ class CreateLocalCodeReviewRunResponseErrorCode(betterproto.Enum):
     REPO_NOT_FOUND = 3
     PATCH_INVALID = 4
     RATE_LIMITED = 5
+    NO_SEAT = 6
 
 
 class GetCodeReviewRunStatusResponseErrorCode(betterproto.Enum):
@@ -268,12 +269,25 @@ class GetObservableServiceInfoResponse(betterproto.Message):
 class CreateLocalCodeReviewRunRequest(betterproto.Message):
     owner_name: str = betterproto.string_field(1)
     repo_name: str = betterproto.string_field(2)
-    base_sha: str = betterproto.string_field(3)
-    """Commit the patch applies on top of"""
+    last_pushed_sha: str = betterproto.string_field(3)
+    """Most recent commit on this branch reachable on origin"""
 
     patch: bytes = betterproto.bytes_field(4)
+    """
+    Diff between `last_pushed_sha` and the working tree (unpushed commits
+     + uncommitted changes only)
+    """
+
     min_severity: Optional[str] = betterproto.string_field(5, optional=True)
     cli_version: str = betterproto.string_field(6)
+    branch_name: str = betterproto.string_field(7)
+    """
+    Current branch name. Backend uses it to look up the open PR for seat
+     resolution, `base_branch` defaulting, and PR context.
+    """
+
+    local_head_sha: str = betterproto.string_field(8)
+    """The user's actual local HEAD commit"""
 
 
 @dataclass(eq=False, repr=False)

--- a/generated/ts/backend/code_review_service.ts
+++ b/generated/ts/backend/code_review_service.ts
@@ -28,12 +28,15 @@ export interface CreateLocalCodeReviewRunRequest {
      */
     repoName: string;
     /**
-     * Commit the patch applies on top of
+     * Most recent commit on this branch reachable on origin
      *
-     * @generated from protobuf field: string base_sha = 3
+     * @generated from protobuf field: string last_pushed_sha = 3
      */
-    baseSha: string;
+    lastPushedSha: string;
     /**
+     * Diff between `last_pushed_sha` and the working tree (unpushed commits
+     * + uncommitted changes only)
+     *
      * @generated from protobuf field: bytes patch = 4
      */
     patch: Uint8Array;
@@ -45,6 +48,19 @@ export interface CreateLocalCodeReviewRunRequest {
      * @generated from protobuf field: string cli_version = 6
      */
     cliVersion: string;
+    /**
+     * Current branch name. Backend uses it to look up the open PR for seat
+     * resolution, `base_branch` defaulting, and PR context.
+     *
+     * @generated from protobuf field: string branch_name = 7
+     */
+    branchName: string;
+    /**
+     * The user's actual local HEAD commit
+     *
+     * @generated from protobuf field: string local_head_sha = 8
+     */
+    localHeadSha: string;
 }
 /**
  * @generated from protobuf message tusk.drift.backend.v1.CreateLocalCodeReviewRunResponseSuccess
@@ -290,7 +306,11 @@ export enum CreateLocalCodeReviewRunResponseErrorCode {
     /**
      * @generated from protobuf enum value: CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_RATE_LIMITED = 5;
      */
-    RATE_LIMITED = 5
+    RATE_LIMITED = 5,
+    /**
+     * @generated from protobuf enum value: CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_NO_SEAT = 6;
+     */
+    NO_SEAT = 6
 }
 /**
  * @generated from protobuf enum tusk.drift.backend.v1.GetCodeReviewRunStatusResponseErrorCode
@@ -340,19 +360,23 @@ class CreateLocalCodeReviewRunRequest$Type extends MessageType<CreateLocalCodeRe
         super("tusk.drift.backend.v1.CreateLocalCodeReviewRunRequest", [
             { no: 1, name: "owner_name", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 2, name: "repo_name", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 3, name: "base_sha", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 3, name: "last_pushed_sha", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 4, name: "patch", kind: "scalar", T: 12 /*ScalarType.BYTES*/ },
             { no: 5, name: "min_severity", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
-            { no: 6, name: "cli_version", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+            { no: 6, name: "cli_version", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 7, name: "branch_name", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 8, name: "local_head_sha", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<CreateLocalCodeReviewRunRequest>): CreateLocalCodeReviewRunRequest {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.ownerName = "";
         message.repoName = "";
-        message.baseSha = "";
+        message.lastPushedSha = "";
         message.patch = new Uint8Array(0);
         message.cliVersion = "";
+        message.branchName = "";
+        message.localHeadSha = "";
         if (value !== undefined)
             reflectionMergePartial<CreateLocalCodeReviewRunRequest>(this, message, value);
         return message;
@@ -368,8 +392,8 @@ class CreateLocalCodeReviewRunRequest$Type extends MessageType<CreateLocalCodeRe
                 case /* string repo_name */ 2:
                     message.repoName = reader.string();
                     break;
-                case /* string base_sha */ 3:
-                    message.baseSha = reader.string();
+                case /* string last_pushed_sha */ 3:
+                    message.lastPushedSha = reader.string();
                     break;
                 case /* bytes patch */ 4:
                     message.patch = reader.bytes();
@@ -379,6 +403,12 @@ class CreateLocalCodeReviewRunRequest$Type extends MessageType<CreateLocalCodeRe
                     break;
                 case /* string cli_version */ 6:
                     message.cliVersion = reader.string();
+                    break;
+                case /* string branch_name */ 7:
+                    message.branchName = reader.string();
+                    break;
+                case /* string local_head_sha */ 8:
+                    message.localHeadSha = reader.string();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -398,9 +428,9 @@ class CreateLocalCodeReviewRunRequest$Type extends MessageType<CreateLocalCodeRe
         /* string repo_name = 2; */
         if (message.repoName !== "")
             writer.tag(2, WireType.LengthDelimited).string(message.repoName);
-        /* string base_sha = 3; */
-        if (message.baseSha !== "")
-            writer.tag(3, WireType.LengthDelimited).string(message.baseSha);
+        /* string last_pushed_sha = 3; */
+        if (message.lastPushedSha !== "")
+            writer.tag(3, WireType.LengthDelimited).string(message.lastPushedSha);
         /* bytes patch = 4; */
         if (message.patch.length)
             writer.tag(4, WireType.LengthDelimited).bytes(message.patch);
@@ -410,6 +440,12 @@ class CreateLocalCodeReviewRunRequest$Type extends MessageType<CreateLocalCodeRe
         /* string cli_version = 6; */
         if (message.cliVersion !== "")
             writer.tag(6, WireType.LengthDelimited).string(message.cliVersion);
+        /* string branch_name = 7; */
+        if (message.branchName !== "")
+            writer.tag(7, WireType.LengthDelimited).string(message.branchName);
+        /* string local_head_sha = 8; */
+        if (message.localHeadSha !== "")
+            writer.tag(8, WireType.LengthDelimited).string(message.localHeadSha);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/proto/backend/code_review_service.proto
+++ b/proto/backend/code_review_service.proto
@@ -44,7 +44,7 @@ message CreateLocalCodeReviewRunRequest {
   optional string min_severity = 5;
   string cli_version = 6;
 
-  // Current branch name. Backend uses it to look up the opekn PR for seat
+  // Current branch name. Backend uses it to look up the open PR for seat
   // resolution, `base_branch` defaulting, and PR context.
   string branch_name = 7;
 

--- a/proto/backend/code_review_service.proto
+++ b/proto/backend/code_review_service.proto
@@ -34,11 +34,22 @@ message CreateLocalCodeReviewRunRequest {
   string owner_name = 1;
   string repo_name = 2;
 
-  // Commit the patch applies on top of
-  string base_sha = 3;
+  // Most recent commit on this branch reachable on origin
+  string last_pushed_sha = 3;
+
+  // Diff between `last_pushed_sha` and the working tree (unpushed commits
+  // + uncommitted changes only)
   bytes patch = 4;
+
   optional string min_severity = 5;
   string cli_version = 6;
+
+  // Current branch name. Backend uses it to look up the opekn PR for seat
+  // resolution, `base_branch` defaulting, and PR context.
+  string branch_name = 7;
+
+  // The user's actual local HEAD commit
+  string local_head_sha = 8;
 }
 
 message CreateLocalCodeReviewRunResponseSuccess {
@@ -52,6 +63,7 @@ enum CreateLocalCodeReviewRunResponseErrorCode {
   CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_REPO_NOT_FOUND = 3;
   CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_PATCH_INVALID = 4;
   CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_RATE_LIMITED = 5;
+  CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_NO_SEAT = 6;
 }
 
 message CreateLocalCodeReviewRunResponseError {


### PR DESCRIPTION
### Summary
Updates the `CreateLocalCodeReviewRunRequest` in the code review service proto to give the backend enough context to resolve the user's seat via their open PR, default base branches, and reason about pushed vs. unpushed changes. Also adds a `NO_SEAT` error code for when seat resolution fails.
### Changes
- Renamed `base_sha` → `last_pushed_sha` to clarify it is the most recent commit reachable on origin (not an arbitrary base).
- Clarified that `patch` represents the diff between `last_pushed_sha` and the working tree (unpushed commits + uncommitted changes).
- Added `branch_name`
- Added `local_head_sha`
- Added `CREATE_LOCAL_CODE_REVIEW_RUN_RESPONSE_ERROR_CODE_NO_SEAT` error code.
- Regenerated Go, TypeScript, and Python bindings to match.
